### PR TITLE
import confint & vcov in order to define methods on them

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,13 +2,13 @@ import(methods, MASS, nnet, Rsolnp)
 
 importFrom(stats, predict, simulate)
 
-importFrom("stats", "confint", "cov", "cov.wt", "dbinom", "dgamma", "dmultinom",
+importFrom("stats", "cov", "cov.wt", "dbinom", "dgamma", "dmultinom",
              "dnorm", "qnorm", "dpois", "gaussian", "glm.fit", "lm.fit",
              "lm.wfit", "mahalanobis", "make.link", "model.frame",
              "model.matrix", "model.response", "pchisq", "rbinom",
              "rgamma", "rmultinom", "rnorm", "rpois", "sd")
 
-importFrom(stats4, AIC, BIC, logLik, nobs, summary, vcov)
+importFrom(stats4, AIC, BIC, confint, logLik, nobs, summary, vcov)
 
 importFrom(nlme, fdHess)
 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,11 +2,11 @@ import(methods, MASS, nnet, Rsolnp)
 
 importFrom(stats, predict, simulate)
 
-importFrom("stats", "cov", "cov.wt", "dbinom", "dgamma", "dmultinom",
+importFrom("stats", "confint", "cov", "cov.wt", "dbinom", "dgamma", "dmultinom",
              "dnorm", "qnorm", "dpois", "gaussian", "glm.fit", "lm.fit",
              "lm.wfit", "mahalanobis", "make.link", "model.frame",
              "model.matrix", "model.response", "pchisq", "rbinom",
-             "rgamma", "rmultinom", "rnorm", "rpois", "sd")
+             "rgamma", "rmultinom", "rnorm", "rpois", "sd", "vcov")
 
 importFrom(stats4, AIC, BIC, logLik, nobs, summary)
 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -6,9 +6,9 @@ importFrom("stats", "confint", "cov", "cov.wt", "dbinom", "dgamma", "dmultinom",
              "dnorm", "qnorm", "dpois", "gaussian", "glm.fit", "lm.fit",
              "lm.wfit", "mahalanobis", "make.link", "model.frame",
              "model.matrix", "model.response", "pchisq", "rbinom",
-             "rgamma", "rmultinom", "rnorm", "rpois", "sd", "vcov")
+             "rgamma", "rmultinom", "rnorm", "rpois", "sd")
 
-importFrom(stats4, AIC, BIC, logLik, nobs, summary)
+importFrom(stats4, AIC, BIC, logLik, nobs, summary, vcov)
 
 importFrom(nlme, fdHess)
 


### PR DESCRIPTION
```shell
R_DEFAULT_PACKAGES=NULL Rscript -e "library(depmixS4)"
```

will fail with:

```
Error: no function found corresponding to methods exports from ‘depmixS4’ for: ‘confint’, ‘vcov’
```

If we do `importFrom(stats, vcov)`, then the example in vcov.Rd fails:

```r
standardError(fmod1)
# Error in UseMethod("vcov") : 
#   no applicable method for 'vcov' applied to an object of class "c('depmix.fitted', 'depmix', 'mix')"
```

From `UseMethod()`, we can infer that S3 dispatch was attempted, meaning we're missing the S4 generic on `vcov()` --> need to import `vcov()` from {stats4} instead.

Pulling `confint()` from {stats} not {stats4} doesn't _break_ anything, but I suspect pulling it from {stats4} is intended based on the S4 method for `mix` class.